### PR TITLE
Update links to openfusion-dev

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,6 +6,15 @@ Results are returned in GeoJSON format.
 
 |Build Status| |Test Coverage| |Documentation Status| |Latest Release|
 
+.. |Build Status| image:: https://img.shields.io/travis/com/openfusion-dev/ogre.svg
+   :target: https://travis-ci.com/openfusion-dev/ogre
+.. |Test Coverage| image:: https://img.shields.io/coveralls/openfusion-dev/ogre.svg
+   :target: https://coveralls.io/github/openfusion-dev/ogre
+.. |Documentation Status| image:: https://readthedocs.org/projects/ogre/badge/?version=latest
+   :target: https://ogre.readthedocs.org/
+.. |Latest Release| image:: https://img.shields.io/pypi/v/ogre.svg
+   :target: https://pypi.python.org/pypi/OGRe
+
 Documentation
 -------------
 https://ogre.readthedocs.io/
@@ -28,12 +37,3 @@ General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License
 along with this library; if not, write to the Free Software Foundation,
 Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
-
-.. |Build Status| image:: https://img.shields.io/travis/dmtucker/ogre.svg
-   :target: https://travis-ci.org/dmtucker/ogre
-.. |Test Coverage| image:: https://img.shields.io/coveralls/dmtucker/ogre.svg
-   :target: https://coveralls.io/github/dmtucker/ogre
-.. |Documentation Status| image:: https://readthedocs.org/projects/ogre/badge/?version=latest
-   :target: https://ogre.readthedocs.org/
-.. |Latest Release| image:: https://img.shields.io/pypi/v/ogre.svg
-   :target: https://pypi.python.org/pypi/OGRe

--- a/docs/about.rst
+++ b/docs/about.rst
@@ -50,7 +50,7 @@ public sources such as Twitter. It merges the results with gathered data and
 writes the combined set to a GeoJSON file that gets handed off to the
 visualizer.
 
-.. seealso:: https://github.com/dmtucker/ogre
+.. seealso:: https://github.com/openfusion-dev/ogre
 
 Visualizer
 ~~~~~~~~~~
@@ -59,4 +59,4 @@ the web application via AJAX and plots it on a map or timeline.
 Vizit is capable of rendering any GeoJSON file, and it supports a number of
 special properties to affect the resulting visualization.
 
-.. seealso:: https://github.com/dmtucker/vizit
+.. seealso:: https://github.com/openfusion-dev/vizit

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -28,7 +28,7 @@ To get OGRe, use one of the following methods:
 
 .. code-block:: bash
 
-   $ git clone http://github.com/dmtucker/ogre.git
+   $ git clone http://github.com/openfusion-dev/ogre.git
    $ cd ogre
    $ python setup.py install
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     author='David Tucker',
     author_email='dmtucker@ucsc.edu',
     license='LGPLv2+',
-    url='https://github.com/dmtucker/ogre',
+    url='https://github.com/openfusion-dev/ogre',
     packages=find_packages(exclude=['docs']),
     include_package_data=True,
     test_suite="ogre.test",


### PR DESCRIPTION
Everything, including Travis CI and Coveralls, should point to openfusion-dev now instead of dmtucker.