### PR TITLE
Remove Read the Docs references

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,18 +4,14 @@ OGRe fetches geotagged data from publicly available APIs based on a provided
 keyword, location, period of time, or media type.
 Results are returned in GeoJSON format.
 
-|Build Status| |Documentation Status| |Latest Release|
+|Latest Release|
 
-.. |Build Status| image:: https://img.shields.io/travis/com/openfusion-dev/ogre.svg
-   :target: https://travis-ci.com/openfusion-dev/ogre
-.. |Documentation Status| image:: https://readthedocs.org/projects/ogre/badge/?version=latest
-   :target: https://ogre.readthedocs.org/
 .. |Latest Release| image:: https://img.shields.io/pypi/v/ogre.svg
    :target: https://pypi.python.org/pypi/OGRe
 
 Documentation
 -------------
-https://ogre.readthedocs.io/
+https://openfusion-dev.github.io/ogre/
 
 License
 -------

--- a/src/ogre/cli.py
+++ b/src/ogre/cli.py
@@ -1,8 +1,4 @@
-"""
-Make queries using OGRe directly.
-
-See https://ogre.readthedocs.org/en/latest/ for more information.
-"""
+"""Make queries using OGRe directly."""
 
 import argparse
 import json


### PR DESCRIPTION
[RTD requires a config file now](https://blog.readthedocs.com/migrate-configuration-v2/), but the project is already set up for GitHub Pages.